### PR TITLE
Add the ability to search every drive and Steam Library on the computer

### DIFF
--- a/SunshineGameFinder/Program.cs
+++ b/SunshineGameFinder/Program.cs
@@ -139,7 +139,7 @@ rootCommand.SetHandler((addlDirectories, addlExeExclusionWords, sunshineConfigLo
         var file = new FileInfo(libraryFoldersPath);
         if (!file.Exists)
         {
-            Logger.Log($"{file.FullName} does not exist, skipping...", LogLevel.Warning);
+            Logger.Log($"libraryfolders.vdf not found on {file.DirectoryName}, skipping...", LogLevel.Warning);
             continue;
         }
         var libraries = VdfConvert.Deserialize(File.ReadAllText(libraryFoldersPath));

--- a/SunshineGameFinder/Program.cs
+++ b/SunshineGameFinder/Program.cs
@@ -60,7 +60,10 @@ rootCommand.SetHandler((addlDirectories, addlExeExclusionWords, sunshineConfigLo
     var sunshineAppInstance = JsonConvert.DeserializeObject<SunshineConfig>(File.ReadAllText(sunshineAppsJson));
     var gamesAdded = 0;
     if (sunshineAppInstance == null)
+    {
+        Logger.Log($"Sunshite app list is null", LogLevel.Error);
         return;
+    }
 
     void ScanFolder(string folder)
     {

--- a/SunshineGameFinder/Program.cs
+++ b/SunshineGameFinder/Program.cs
@@ -165,7 +165,14 @@ rootCommand.SetHandler((addlDirectories, addlExeExclusionWords, sunshineConfigLo
         }
     }
     Logger.Log("Finding Games Completed");
-    if (FileWriter.UpdateConfig(sunshineAppsJson, sunshineAppInstance))
+    if (gamesAdded > 0)
+    {
+        if (FileWriter.UpdateConfig(sunshineAppsJson, sunshineAppInstance))
+        {
+            Logger.Log($"Apps config is updated! {gamesAdded} games were added. Check Sunshine to ensure all games were added.", LogLevel.Success);
+        }
+    }
+    else
     {
         Logger.Log("No new games were found to be added to Sunshine");
     }

--- a/SunshineGameFinder/Program.cs
+++ b/SunshineGameFinder/Program.cs
@@ -11,7 +11,7 @@ const string wildcatDrive = @"*:\";
 const string steamLibraryFolders = @"Program Files (x86)\Steam\steamapps\libraryfolders.vdf";
 
 // default values
-var gameDirs = new List<string>() { @"*:\Program Files (x86)\Steam\steamapps\common", @"*:\XboxGames", @"*:\Program Files\EA Games" };
+var gameDirs = new List<string>() { @"*:\Program Files (x86)\Steam\steamapps\common", @"*:\XboxGames", @"*:\Program Files\EA Games", @"*:\Program Files\Epic Games\" };
 var exclusionWords = new List<string>() { "Steam" };
 var exeExclusionWords = new List<string>() { "Steam", "Cleanup", "DX", "Uninstall", "Touchup", "redist", "Crash", "Editor" };
 

--- a/SunshineGameFinder/SunshineGameFinder.csproj
+++ b/SunshineGameFinder/SunshineGameFinder.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Gameloop.Vdf" Version="0.6.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>


### PR DESCRIPTION
Two main features added:

1) It'll now search on every drive. E.g. Aside of looking on C:\\...\\Steam, it'll also search on D:\\...\\Steam, E:\\...\\Steam and go on (obviously only on available drives).

2) It'll also look at *:\Program Files (x86)\Steam\steamapps\libraryfolders.vdf file to get every Steam Library on the computer, not just *:\Program Files (x86)\Steam\steamapps\common\

For the second feature, I added the [Gameloop.Vdf](https://github.com/shravan2x/Gameloop.Vdf) library [(License)](https://github.com/shravan2x/Gameloop.Vdf/blob/master/LICENSE)