### PR TITLE
v1.7.0: August 2024 Update

### DIFF
--- a/SunshineGameFinder/ImageScraper.cs
+++ b/SunshineGameFinder/ImageScraper.cs
@@ -1,10 +1,4 @@
 ﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SunshineGameFinder
 {
@@ -154,10 +148,11 @@ namespace SunshineGameFinder
                 int gameId = await GetIDForGame(gameName);
                 var rawJson = await (await HttpClient.GetAsync(gameTemplate.Replace("@ID", gameId.ToString()))).Content.ReadAsStringAsync();
                 var game = JsonConvert.DeserializeObject<Game>(rawJson);
+                if (game == null) return null;
                 var coverUrl = game.cover.url;
                 var stream = await (await HttpClient.GetAsync("https:" + coverUrl.Replace("thumb", "cover_big"))).Content.ReadAsStreamAsync();
 
-                string fullpath = coversFolderPath + gameId.ToString() + ".jpg";
+                string fullpath = coversFolderPath + gameId.ToString() + ".png";
                 using FileStream fs = new(fullpath, FileMode.OpenOrCreate);
                 stream.Position = 0;
                 await stream.CopyToAsync(fs);

--- a/SunshineGameFinder/Program.cs
+++ b/SunshineGameFinder/Program.cs
@@ -111,7 +111,7 @@ rootCommand.SetHandler((addlDirectories, addlExeExclusionWords, sunshineConfigLo
         foreach (var gameDir in di.GetDirectories())
         {
             Logger.Log($"Looking for game exe in {gameDir}...");
-            var gameName = gameDir.Name;
+            var gameName = CleanGameName(gameDir.Name);
             if (exclusionWords.Any(ew => gameName.Contains(ew)))
             {
                 Logger.Log($"Skipping {gameName} as it was an excluded word match...");
@@ -152,7 +152,7 @@ rootCommand.SetHandler((addlDirectories, addlExeExclusionWords, sunshineConfigLo
                         workingdir = ""
                     };
                 }
-                string coversFolderPath = sunshineRootFolder + "/covers/";
+                string coversFolderPath = Path.GetFullPath(sunshineRootFolder.Replace("\\", "/") + "/covers/");
                 string fullPathOfCoverImage = ImageScraper.SaveIGDBImageToCoversFolder(gameName, coversFolderPath).Result;
                 if (!string.IsNullOrEmpty(fullPathOfCoverImage))
                 {
@@ -222,4 +222,15 @@ rootCommand.SetHandler((addlDirectories, addlExeExclusionWords, sunshineConfigLo
     }
 
 }, addlDirectoriesOption, addlExeExclusionWords, sunshineConfigLocationOption, forceOption, removeUninstalledOption);
+
+string CleanGameName(string name)
+{
+    string[] toReplace = new string[] { "Win10", "Windows 10", "Win11", "Windows 11" };
+    foreach (string toRemove in toReplace)
+    {
+        name = name.Replace(toRemove, "");
+    }
+    return name.Trim();
+}
+
 rootCommand.Invoke(args);

--- a/SunshineGameFinder/SunshineAppsConfig.cs
+++ b/SunshineGameFinder/SunshineAppsConfig.cs
@@ -19,6 +19,17 @@ namespace SunshineGameFinder
 
         [JsonProperty("working-dir")]
         public string workingdir { get; set; }
+
+        [JsonProperty("exclude-global-prep-cmd")]
+        public bool excludeglobalprepcmd { get; set; }
+        public bool elevated { get; set; }
+        [JsonProperty("auto-detach")]
+        public bool autodetach { get; set; }
+        [JsonProperty("wait-all")]
+        public bool waitall { get; set; }
+
+        [JsonProperty("exit-timeout")]
+        public int exittimeout { get; set; } = 5;
     }
 
     public class Env

--- a/SunshineGameFinder/SunshineGameFinder.csproj
+++ b/SunshineGameFinder/SunshineGameFinder.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<PublishTrimmed>true</PublishTrimmed>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<Title>Sunshine Game Finder</Title>
@@ -13,8 +13,8 @@
 		<RepositoryUrl>https://github.com/JMTK/SunshineGameFinder</RepositoryUrl>
 		<GenerateDocumentationFile>False</GenerateDocumentationFile>
 		<SignAssembly>False</SignAssembly>
-		<AssemblyVersion>1.6.0</AssemblyVersion>
-		<FileVersion>1.6.0</FileVersion>
+		<AssemblyVersion>1.7.0</AssemblyVersion>
+		<FileVersion>1.7.0</FileVersion>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
- Add support for new Sunshine app properties
- Fix cover images not showing up in clients
- Clean game name from common suffixes being appended to PC editions
- Update to .NET 8